### PR TITLE
fix: add permission contents read to basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ jobs:
   diff_dependencies:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Checkout repository

--- a/recipes/basic.yml
+++ b/recipes/basic.yml
@@ -7,6 +7,7 @@ jobs:
   diff_dependencies:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
action fails to access (private) repository without `permissions: contents: read`

`contents: read`might also be needed in the extended example but is out of scope here