### PR TITLE
feat: add `exclude-packages` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ jobs:
 | `dependency-threshold` | Threshold for warning about significant increase in number of dependencies | No | `10` |
 | `size-threshold` | Threshold (in bytes) for warning about significant increase in package size | No | `100000` |
 | `duplicate-threshold` | Threshold for warning about packages with multiple versions | No | `1` |
+| `exclude-packages` | Regular expression pattern to exclude packages from analysis | No | None |
 | `base-packages` | Glob pattern for base branch pack files (e.g., `"./base-packs/*.tgz"`) | No | None |
 | `source-packages` | Glob pattern for source branch pack files (e.g., `"./source-packs/*.tgz"`) | No | None |
 | `pack-size-threshold` | Threshold (in bytes) for warning about significant increase in total pack size | No | `50000` |

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
     description: 'Threshold for warning about packages with multiple versions'
     required: false
     default: '1'
+  exclude-packages:
+    description: 'Regular expression pattern to exclude packages from analysis'
+    required: false
 
 runs:
   using: node24


### PR DESCRIPTION
Using this, you can specify a RegExp which will be used to exclude
package names from metrics.
