### PR TITLE
node --run is faster than npm run.

### DIFF
--- a/.github/workflows/diff-dependencies.yml
+++ b/.github/workflows/diff-dependencies.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci --ignore-scripts
       - name: Build
-        run: npm run build
+        run: node --run build
       - name: Pack
         run: npm pack
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -37,7 +37,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci --ignore-scripts
       - name: Build
-        run: npm run build
+        run: node --run build
       - name: Pack
         run: npm pack
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Build
-        run: npm run build
+        run: node --run build
       - name: Lint
-        run: npm run lint
+        run: node --run lint
       - name: Test
-        run: npm run test
+        run: node --run test

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "format": "prettier --write src test",
-    "lint": "npm run lint:format && npm run lint:js && npm run lint:types",
+    "lint": "node --run lint:format && node --run lint:js && node --run lint:types",
     "lint:format": "prettier --check src test",
     "lint:js": "eslint src test",
     "lint:types": "tsc --noEmit",

--- a/recipes/bundle-diff.yml
+++ b/recipes/bundle-diff.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci --ignore-scripts
       - name: Build
-        run: npm run build
+        run: node --run build
       - name: Pack
         run: npm pack
 
@@ -44,7 +44,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci --ignore-scripts
       - name: Build
-        run: npm run build
+        run: node --run build
       - name: Pack
         run: npm pack
 


### PR DESCRIPTION
This repository uses Node.js 24, so we can take advantage of node --run, which has been available since Node.js 22.

```
❯ hyperfine "node --run build" "npm run build"
Benchmark 1: node --run build
  Time (mean ± σ):      91.0 ms ±   6.0 ms    [User: 177.0 ms, System: 36.7 ms]
  Range (min … max):    87.8 ms … 118.2 ms    24 runs
 
  Warning: The first benchmarking run for this command was significantly slower than the rest (118.2 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.
 
Benchmark 2: npm run build
  Time (mean ± σ):     173.7 ms ±  41.1 ms    [User: 240.8 ms, System: 51.6 ms]
  Range (min … max):   154.6 ms … 300.2 ms    13 runs
 
  Warning: The first benchmarking run for this command was significantly slower than the rest (212.2 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.
 
Summary
  node --run build ran
    1.91 ± 0.47 times faster than npm run build
```

see: https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-4/

In my testing, `bun run script` was the fastest. I haven’t looked into the reasons yet, but it outperforms the others.
