### PR TITLE
fix: raise errors and skip artifacts

### DIFF
--- a/.github/workflows/diff-dependencies-comment.yml
+++ b/.github/workflows/diff-dependencies-comment.yml
@@ -21,7 +21,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Post Comment
-        uses: e18e/action-dependency-diff@27a5e97505c6a13fbe1eece3388bd16e58888548 # pre-release
+        uses: e18e/action-dependency-diff@b7fa825f127c85c357b7fd9f481ce4725618de81 # main
         with:
           mode: comment-from-artifact
           artifact-path: e18e-diff-result.json

--- a/.github/workflows/diff-dependencies.yml
+++ b/.github/workflows/diff-dependencies.yml
@@ -72,12 +72,13 @@ jobs:
           path: ./source-packages
       - name: Analyze Dependencies
         id: analyze
-        uses: e18e/action-dependency-diff@27a5e97505c6a13fbe1eece3388bd16e58888548 # pre-release
+        uses: e18e/action-dependency-diff@b7fa825f127c85c357b7fd9f481ce4725618de81 # main
         with:
           mode: artifact
           base-packages: ./base-packages/*.tgz
           source-packages: ./source-packages/*.tgz
       - name: Upload Artifact
+        if: steps.analyze.outputs.artifact-path
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: e18e-diff-result

--- a/build/main.js
+++ b/build/main.js
@@ -24895,10 +24895,9 @@ async function postCommentFromArtifact() {
   const token = getInput("github-token", { required: true });
   const artifactPath = getInput("artifact-path");
   if (!artifactPath) {
-    setFailed(
+    throw new Error(
       "No artifact-path was provided. This is required for comment-from-artifact mode."
     );
-    return;
   }
   info(`Reading artifact from ${artifactPath}`);
   const result = JSON.parse(
@@ -24985,8 +24984,7 @@ async function analyzeAndComment() {
       `Parsed current lockfile with ${parsedCurrentLock.packages.length} packages`
     );
   } catch (err) {
-    setFailed(`Failed to parse current lockfile: ${err}`);
-    return;
+    throw new Error(`Failed to parse current lockfile: ${err}`);
   }
   try {
     parsedBaseLock = await parse2(
@@ -24998,8 +24996,7 @@ async function analyzeAndComment() {
       `Parsed base lockfile with ${parsedBaseLock.packages.length} packages`
     );
   } catch (err) {
-    setFailed(`Failed to parse base lockfile: ${err}`);
-    return;
+    throw new Error(`Failed to parse base lockfile: ${err}`);
   }
   const currentDeps = computeDependencyVersions(parsedCurrentLock);
   const baseDeps = computeDependencyVersions(parsedBaseLock);
@@ -25049,10 +25046,9 @@ async function analyzeAndComment() {
   }
   if (detectReplacements) {
     if (!basePackageJson || !currentPackageJson) {
-      setFailed(
+      throw new Error(
         "detect-replacements requires both base and current package.json to be present"
       );
-      return;
     }
     const baseDependencies = getDependenciesFromPackageJson(basePackageJson, [
       "optional",

--- a/recipes/artifact/analyze.yml
+++ b/recipes/artifact/analyze.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           mode: artifact
       - name: Upload Artifact
+        if: steps.analyze.outputs.artifact-path
         uses: actions/upload-artifact@v4
         with:
           name: e18e-diff-result

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,10 +29,9 @@ async function postCommentFromArtifact(): Promise<void> {
   const artifactPath = core.getInput('artifact-path');
 
   if (!artifactPath) {
-    core.setFailed(
+    throw new Error(
       'No artifact-path was provided. This is required for comment-from-artifact mode.'
     );
-    return;
   }
 
   core.info(`Reading artifact from ${artifactPath}`);
@@ -135,8 +134,9 @@ async function analyzeAndComment(): Promise<void> {
       `Parsed current lockfile with ${parsedCurrentLock.packages.length} packages`
     );
   } catch (err) {
-    core.setFailed(`Failed to parse current lockfile: ${err}`);
-    return;
+    throw new Error(`Failed to parse current lockfile: ${err}`, {
+      cause: err
+    });
   }
   try {
     parsedBaseLock = await parseLockfile(
@@ -148,8 +148,9 @@ async function analyzeAndComment(): Promise<void> {
       `Parsed base lockfile with ${parsedBaseLock.packages.length} packages`
     );
   } catch (err) {
-    core.setFailed(`Failed to parse base lockfile: ${err}`);
-    return;
+    throw new Error(`Failed to parse base lockfile: ${err}`, {
+      cause: err
+    });
   }
 
   const currentDeps = computeDependencyVersions(parsedCurrentLock);
@@ -210,10 +211,9 @@ async function analyzeAndComment(): Promise<void> {
 
   if (detectReplacements) {
     if (!basePackageJson || !currentPackageJson) {
-      core.setFailed(
+      throw new Error(
         'detect-replacements requires both base and current package.json to be present'
       );
-      return;
     }
 
     const baseDependencies = getDependenciesFromPackageJson(basePackageJson, [


### PR DESCRIPTION
When we encounter errors, we now `throw` them and have a single
`setFailed` catch.

We also skip the artifact upload if no outputs were produced.
