### PR TITLE
fix: use pull request head sha for diffs

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -24150,6 +24150,9 @@ function getBaseRef() {
   }
   return "origin/main";
 }
+function getCurrentRef() {
+  return context2.payload.pull_request?.head.sha ?? context2.sha;
+}
 
 // src/npm.ts
 function getProvenance(meta) {
@@ -24944,7 +24947,7 @@ async function analyzeAndComment() {
   const workspacePath = join2(baseWorkspace, workDir);
   info(`Workspace path is ${workspacePath}`);
   const baseRef = getBaseRef();
-  const currentRef = context2.payload.pull_reuqest?.head.sha ?? context2.sha;
+  const currentRef = getCurrentRef();
   const lockfileFilename = detectLockfile(workspacePath);
   info(`Detected lockfile ${lockfileFilename}`);
   const token = getInput("github-token", { required: true });

--- a/src/git.ts
+++ b/src/git.ts
@@ -54,3 +54,7 @@ export function getBaseRef(): string {
 
   return 'origin/main';
 }
+
+export function getCurrentRef(): string {
+  return github.context.payload.pull_request?.head.sha ?? github.context.sha;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,12 @@ import type {PackageJson} from 'pkg-types';
 import {join} from 'node:path';
 import {parse as parseLockfile, type ParsedLockFile} from 'lockparse';
 import {detectLockfile, computeDependencyVersions} from './lockfile.js';
-import {getFileFromRef, getBaseRef, tryGetJSONFromRef} from './git.js';
+import {
+  getFileFromRef,
+  getBaseRef,
+  getCurrentRef,
+  tryGetJSONFromRef
+} from './git.js';
 import {getDependenciesFromPackageJson} from './npm.js';
 import {getPacksFromPattern} from './packs.js';
 import {scanForReplacements} from './checks/replacements.js';
@@ -54,8 +59,7 @@ async function analyzeAndComment(): Promise<void> {
   core.info(`Workspace path is ${workspacePath}`);
 
   const baseRef = getBaseRef();
-  const currentRef =
-    github.context.payload.pull_reuqest?.head.sha ?? github.context.sha;
+  const currentRef = getCurrentRef();
   const lockfileFilename = detectLockfile(workspacePath);
   core.info(`Detected lockfile ${lockfileFilename}`);
 

--- a/test/git_test.ts
+++ b/test/git_test.ts
@@ -60,6 +60,43 @@ describe('getBaseRef', () => {
   });
 });
 
+describe('getCurrentRef', () => {
+  it('should return pull request head sha when in PR context', () => {
+    const originalPayload = github.context.payload;
+    const originalSha = github.context.sha;
+    try {
+      github.context.payload = {
+        pull_request: {
+          number: 303,
+          head: {
+            sha: 'pr-head-sha'
+          }
+        }
+      };
+      github.context.sha = 'merge-sha';
+      const currentRef = git.getCurrentRef();
+      expect(currentRef).toBe('pr-head-sha');
+    } finally {
+      github.context.payload = originalPayload;
+      github.context.sha = originalSha;
+    }
+  });
+
+  it('should fall back to context sha outside pull request context', () => {
+    const originalPayload = github.context.payload;
+    const originalSha = github.context.sha;
+    try {
+      github.context.payload = {};
+      github.context.sha = 'push-sha';
+      const currentRef = git.getCurrentRef();
+      expect(currentRef).toBe('push-sha');
+    } finally {
+      github.context.payload = originalPayload;
+      github.context.sha = originalSha;
+    }
+  });
+});
+
 describe('getFileFromRef', () => {
   afterEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
Fixes the pull request head SHA lookup so fork PRs diff against the actual head commit. There was a typo in `context2.payload.pull_reuqest?.head.sha`.

I noticed it while trying to add the action in a codebase. 