### PR TITLE
ci: remove unnecessary checkout in dependency diff job

### DIFF
--- a/.github/workflows/diff-dependencies.yml
+++ b/.github/workflows/diff-dependencies.yml
@@ -58,10 +58,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: base-packages


### PR DESCRIPTION
Dependency diff runs in artifact mode and compares packed .tgz files, so repository checkout (and full history fetch) is not required.