### PR TITLE
fix: disable duplicate checks when threshold <= 0

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -25085,13 +25085,15 @@ async function analyzeAndComment() {
   info(`Pack size threshold set to ${formatBytes(packSizeThreshold)}`);
   const messages = [];
   scanForDependencyCount(messages, dependencyThreshold, currentDeps, baseDeps);
-  scanForDuplicates(
-    messages,
-    duplicateThreshold,
-    currentDeps,
-    lockfilePath,
-    parsedCurrentLock
-  );
+  if (duplicateThreshold > 0) {
+    scanForDuplicates(
+      messages,
+      duplicateThreshold,
+      currentDeps,
+      lockfilePath,
+      parsedCurrentLock
+    );
+  }
   await scanForDependencySize(
     messages,
     sizeThreshold,

--- a/src/main.ts
+++ b/src/main.ts
@@ -168,13 +168,16 @@ async function analyzeAndComment(): Promise<void> {
   const messages: string[] = [];
 
   scanForDependencyCount(messages, dependencyThreshold, currentDeps, baseDeps);
-  scanForDuplicates(
-    messages,
-    duplicateThreshold,
-    currentDeps,
-    lockfilePath,
-    parsedCurrentLock
-  );
+
+  if (duplicateThreshold > 0) {
+    scanForDuplicates(
+      messages,
+      duplicateThreshold,
+      currentDeps,
+      lockfilePath,
+      parsedCurrentLock
+    );
+  }
 
   await scanForDependencySize(
     messages,


### PR DESCRIPTION
If the threshold is `0`, you're basically saying "show me when a package
has 0 or more versions". This will always be true so is a nonsensical
value.

Similarly, `-1` may be set as a way to turn it off but currently does
the opposite (same as `0`).

This change means `-1` and `0` behave as "turn off duplicate checks".
