### PR TITLE
fix: use base sha for PRs instead of ref

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -24160,9 +24160,9 @@ function getBaseRef() {
   if (inputBaseRef) {
     return inputBaseRef.includes("/") ? inputBaseRef : `origin/${inputBaseRef}`;
   }
-  const githubBaseRef = context2.payload.pull_request?.base.ref;
-  if (githubBaseRef) {
-    return `origin/${githubBaseRef}`;
+  const githubBaseSha = context2.payload.pull_request?.base.sha;
+  if (githubBaseSha) {
+    return githubBaseSha;
   }
   return "origin/main";
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -46,10 +46,10 @@ export function getBaseRef(): string {
     return inputBaseRef.includes('/') ? inputBaseRef : `origin/${inputBaseRef}`;
   }
 
-  const githubBaseRef = github.context.payload.pull_request?.base.ref;
+  const githubBaseSha = github.context.payload.pull_request?.base.sha;
 
-  if (githubBaseRef) {
-    return `origin/${githubBaseRef}`;
+  if (githubBaseSha) {
+    return githubBaseSha;
   }
 
   return 'origin/main';

--- a/test/git_test.ts
+++ b/test/git_test.ts
@@ -30,19 +30,20 @@ describe('getBaseRef', () => {
     }
   });
 
-  it('should return pull request base ref if in PR context', () => {
+  it('should return pull request base sha if in PR context', () => {
     const originalPayload = github.context.payload;
     try {
       github.context.payload = {
         pull_request: {
           number: 303,
           base: {
-            ref: 'develop'
+            ref: 'develop',
+            sha: 'base-sha'
           }
         }
       };
       const baseRef = git.getBaseRef();
-      expect(baseRef).toBe('origin/develop');
+      expect(baseRef).toBe('base-sha');
     } finally {
       github.context.payload = originalPayload;
     }


### PR DESCRIPTION
The ref is a named point, like `main`, so it can point at a different
target to the PR (e.g. outdated branch).

Using the `sha` means we diff against the target commit rather than a
named ref.
